### PR TITLE
Added CODEOWNERS File to the AGA Ratings Application.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# CODEOWNERS File for the AGA Ratings Program
+# https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners
+
+# Global Settings for the Owners
+* @usgo/usgoowners


### PR DESCRIPTION
## Summary
Adds CODEOWNERS file to restrict who can merge pull requests onto master.

## References

* https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners
